### PR TITLE
Adding support for pointer fields with nil value and "omitempty=false"

### DIFF
--- a/sheriff.go
+++ b/sheriff.go
@@ -84,12 +84,6 @@ func Marshal(options *Options, data interface{}) (interface{}, error) {
 		// we want the childs exposed at the toplevel to be
 		// consistent with the embedded json marshaller
 		if val.Kind() == reflect.Ptr {
-			if val.IsNil() { // For pointer fields with nil value, and omitempty not set, we set to nil (null) in JSON
-				if !jsonOpts.Contains("omitempty") {
-					dest[jsonTag] = nil
-				}
-				continue
-			}
 			val = val.Elem()
 		}
 
@@ -150,6 +144,10 @@ func Marshal(options *Options, data interface{}) (interface{}, error) {
 //
 // There is support for types implementing the Marshaller interface, arbitrary structs, slices, maps and base types.
 func marshalValue(options *Options, v reflect.Value) (interface{}, error) {
+	// return nil on nil pointer struct fields
+	if !v.IsValid() || !v.CanInterface() {
+		return nil, nil
+	}
 	val := v.Interface()
 
 	if marshaller, ok := val.(Marshaller); ok {

--- a/sheriff.go
+++ b/sheriff.go
@@ -84,6 +84,12 @@ func Marshal(options *Options, data interface{}) (interface{}, error) {
 		// we want the childs exposed at the toplevel to be
 		// consistent with the embedded json marshaller
 		if val.Kind() == reflect.Ptr {
+			if val.IsNil() { // For pointer fields with nil value, and omitempty not set, we set to nil (null) in JSON
+				if !jsonOpts.Contains("omitempty") {
+					dest[jsonTag] = nil
+				}
+				continue
+			}
 			val = val.Elem()
 		}
 

--- a/sheriff_test.go
+++ b/sheriff_test.go
@@ -464,3 +464,42 @@ func TestMarshal_EmbeddedFieldEmpty(t *testing.T) {
 
 	assert.Equal(t, string(expected), string(actual))
 }
+
+type PointerFieldModel struct {
+	OptionalField *string `json:"optional_field,omitempty"`
+	RequiredField *string `json:"required_field"`
+	OtherField    *string `json:"other_field"`
+}
+
+func TestMarshal_PointerFields(t *testing.T) {
+	// Create a test model instance with nil pointer fields
+	otherFieldValue := "SomeValue"
+	testModel := &PointerFieldModel{
+		OptionalField: nil,
+		RequiredField: nil,
+		OtherField:    &otherFieldValue,
+	}
+
+	o := &Options{
+		Groups:     []string{},
+		ApiVersion: nil,
+	}
+
+	// Marshal the test model
+	actualMap, err := Marshal(o, testModel)
+	assert.NoError(t, err)
+
+	// Convert the result to JSON
+	actual, err := json.Marshal(actualMap)
+	assert.NoError(t, err)
+
+	// Define the expected JSON result
+	expected, err := json.Marshal(map[string]interface{}{
+		"required_field": nil,
+		"other_field":    "SomeValue",
+	})
+	assert.NoError(t, err)
+
+	// Compare the actual and expected JSON results
+	assert.Equal(t, string(expected), string(actual))
+}


### PR DESCRIPTION
This fixes a panic for pointer fields defined _without_ "omitempty" whose value is set to nil. They are now properly marshalled as "null" in the resulting JSON.

This will marshal this field, when `nil`:
```
Id     *uint  `json:"id"`
```

Into this JSON:
```
"id": null
```

If `omitempty` isn't defined on the Go field, it will cause a panic. There are cases where the API designer may want to explicitly have a `null` value returned for pointer types when the value is not set. This addresses this issue.

_Note: The Go standard library already supports this._
